### PR TITLE
Changes/bugs for re-identification pipeline

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
@@ -236,7 +236,7 @@ public class DLPTextToBigQueryStreamingV2 {
                 DLPTransform.newBuilder()
                     .setBatchSize(options.getBatchSize())
                     .setInspectTemplateName(options.getInspectTemplateName())
-                    .setDeidTemplateName(options.getDeidentifyTemplateName())
+                    .setReidTemplateName(options.getReidentifyTemplateName())
                     .setDlpmethod(options.getDLPMethod())
                     .setProjectId(options.getDLPParent())
                     .setHeaders(selectedColumns)

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
@@ -43,6 +43,11 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
 
   void setDeidentifyTemplateName(String value);
 
+  @Description("DLP ReIdentify Template Name")
+  String getReidentifyTemplateName();
+
+  void setReidentifyTemplateName(String value);
+
   @Description("DLP method deid,inspect,reid")
   @Default.Enum("INSPECT")
   DLPMethod getDLPMethod();
@@ -115,10 +120,12 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
 
   void setHeaders(List<String> topic);
 
-  @Description("Number of shards for DLP request batches. "
-      + "Can be used to controls parallelism of DLP requests.")
+  @Description(
+      "Number of shards for DLP request batches. "
+          + "Can be used to controls parallelism of DLP requests.")
   @Default.Integer(100)
   int getNumShardsPerDLPRequestBatching();
+
   void setNumShardsPerDLPRequestBatching(int value);
 
   class FileTypeFactory implements DefaultValueFactory<FileType> {

--- a/src/main/java/com/google/swarm/tokenization/beam/ShardRows.java
+++ b/src/main/java/com/google/swarm/tokenization/beam/ShardRows.java
@@ -57,8 +57,9 @@ public class ShardRows
       throw new RuntimeException(e);
     }
 
-    if(numberOfShards == UNDEFINED_NUMBER_OF_SHARDS) {
-      DLPTextToBigQueryStreamingV2PipelineOptions options = input.getPipeline().getOptions().as(DLPTextToBigQueryStreamingV2PipelineOptions.class);
+    if (numberOfShards == UNDEFINED_NUMBER_OF_SHARDS) {
+      DLPTextToBigQueryStreamingV2PipelineOptions options =
+          input.getPipeline().getOptions().as(DLPTextToBigQueryStreamingV2PipelineOptions.class);
       numberOfShards = options.getNumShardsPerDLPRequestBatching();
     }
 

--- a/src/main/java/com/google/swarm/tokenization/common/BigQueryDynamicWriteTransform.java
+++ b/src/main/java/com/google/swarm/tokenization/common/BigQueryDynamicWriteTransform.java
@@ -67,14 +67,15 @@ public abstract class BigQueryDynamicWriteTransform
   @Override
   public WriteResult expand(PCollection<KV<String, TableRow>> input) {
 
-    Write<KV<String, TableRow>> transform = BigQueryIO.<KV<String, TableRow>>write()
-        .to(new BQDestination(datasetId(), projectId()))
-        .withFormatFunction(KV::getValue)
-        .withWriteDisposition(WriteDisposition.WRITE_APPEND)
-        .withoutValidation()
-        .ignoreInsertIds()
-        .withMethod(Write.Method.STREAMING_INSERTS)
-        .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED);
+    Write<KV<String, TableRow>> transform =
+        BigQueryIO.<KV<String, TableRow>>write()
+            .to(new BQDestination(datasetId(), projectId()))
+            .withFormatFunction(KV::getValue)
+            .withWriteDisposition(WriteDisposition.WRITE_APPEND)
+            .withoutValidation()
+            .ignoreInsertIds()
+            .withMethod(Write.Method.STREAMING_INSERTS)
+            .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED);
 
     if (input.getPipeline().getOptions().as(StreamingOptions.class).isStreaming()) {
       transform = transform.withAutoSharding();

--- a/src/main/java/com/google/swarm/tokenization/common/DLPTransform.java
+++ b/src/main/java/com/google/swarm/tokenization/common/DLPTransform.java
@@ -56,6 +56,9 @@ public abstract class DLPTransform
   @Nullable
   public abstract String deidTemplateName();
 
+  @Nullable
+  public abstract String reidTemplateName();
+
   public abstract Integer batchSize();
 
   public abstract String projectId();
@@ -73,7 +76,9 @@ public abstract class DLPTransform
 
     public abstract Builder setInspectTemplateName(String inspectTemplateName);
 
-    public abstract Builder setDeidTemplateName(String inspectTemplateName);
+    public abstract Builder setDeidTemplateName(String deidTemplateName);
+
+    public abstract Builder setReidTemplateName(String reidTemplateName);
 
     public abstract Builder setBatchSize(Integer batchSize);
 
@@ -145,7 +150,7 @@ public abstract class DLPTransform
                       .setColumnDelimiter(columnDelimiter())
                       .setHeaderColumns(headers())
                       .setInspectTemplateName(inspectTemplateName())
-                      .setReidentifyTemplateName(deidTemplateName())
+                      .setReidentifyTemplateName(reidTemplateName())
                       .setProjectId(projectId())
                       .build())
               .apply(
@@ -200,7 +205,7 @@ public abstract class DLPTransform
       extends DoFn<KV<String, DeidentifyContentResponse>, KV<String, TableRow>> {
 
     private final Counter numberOfRowDeidentified =
-        Metrics.counter(ConvertDeidResponse.class, "numberOfRowDeidentified");
+        Metrics.counter(ConvertReidResponse.class, "numberOfRowDeidentified");
 
     @ProcessElement
     public void processElement(

--- a/src/main/java/com/google/swarm/tokenization/tool/DLPTemplateHelper.java
+++ b/src/main/java/com/google/swarm/tokenization/tool/DLPTemplateHelper.java
@@ -97,6 +97,7 @@ public class DLPTemplateHelper {
       LOG.error("Unable to read {} file from the resources folder!", DLP_DEID_CONFIG_FILE, e);
     }
 
+    //schema
     return schemaJson;
   }
 }


### PR DESCRIPTION
- Bug fix: DLP templates for records are case sensetive. Query for re-identification of deidentified data is changed to inculde camle case.
- Added reidentification into pipeline option: to decouple input parameters confusion and decoupling args reidentification parameter added into options.
- Batch command for re-identification pipeline  is changed in README.