### PR TITLE
re-identification bug fix + pipeline run decoupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV
 ## ReIdentification From BigQuery 
 You can. use the pipeline to read from BgQuery table and publish the re-identification data in a secure pub sub topic.
 
-Export the Standard SQL Query to read data from bigQuery
+Export the Standard SQL Query to read data from bigQuery. 
+DLP templates are case-sensitive, for records to be identified camelcase of fields should be used as DLP template name. One example from our solution guide:
 One example from our solution guide:
 ```
-export QUERY="select id,card_number,card_holders_name from \`${PROJECT_ID}.${BQ_DATASET_NAME}.100000CCRecords\` where safe_cast(credit_limit as int64)>100000 and safe_cast (age as int64)>50 group by id,card_number,card_holders_name limit 10"
+export QUERY="select id,card_number as Card_Number,card_holders_name as Card_Holders_Name  from \`${PROJECT_ID}.${BQ_DATASET_NAME}.100000CCRecords\` where safe_cast(credit_limit as int64)>100000 and safe_cast (age as int64)>50 group by id,card_number,card_holders_name limit 10"
 ```
 Create a gcs file with the query:
 
@@ -87,6 +88,13 @@ cat << EOF | gsutil cp - gs://${REID_QUERY_BUCKET}/reid_query.sql
 ${QUERY}
 EOF
 ```
+
+Batch re-identification run of the pipeline requires following parameters:
+
+```
+gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs="--region=<region> --project=<project_id> --tempLocation=gs://<bucket>/temp --numWorkers=5 --maxNumWorkers=10 --runner=DataflowRunner --tableRef=<project_id>:<dataset>.<table> --dataset=<dataset> --topic=projects/<project_id>/topics/<name> --workerMachineType=n1-highmem-4 --reidentifyTemplateName=projects/<project_id>/deidentifyTemplates/<name> --DLPMethod=REID --keyRange=1024 --queryPath=gs://<gcs_reid_query_bucket>/reid_query.sql"
+
+``` 
 Run the pipeline by passing required parameters:
 ```
 gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs="--region=<region> --project=<project_id> --streaming --enableStreamingEngine --tempLocation=gs://<bucket>/temp --numWorkers=5 --maxNumWorkers=10 --runner=DataflowRunner --tableRef=<project_id>:<dataset>.<table> --dataset=<dataset> --topic=projects/<project_id>/topics/<name> --autoscalingAlgorithm=THROUGHPUT_BASED --workerMachineType=n1-highmem-4 --deidentifyTemplateName=projects/<project_id>/deidentifyTemplates/<name> --DLPMethod=REID --keyRange=1024 --queryPath=gs://<gcs_reid_query_bucket>/reid_query.sql"

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
@@ -236,7 +236,7 @@ public class DLPTextToBigQueryStreamingV2 {
                 DLPTransform.newBuilder()
                     .setBatchSize(options.getBatchSize())
                     .setInspectTemplateName(options.getInspectTemplateName())
-                    .setDeidTemplateName(options.getDeidentifyTemplateName())
+                    .setReidTemplateName(options.getReidentifyTemplateName())
                     .setDlpmethod(options.getDLPMethod())
                     .setProjectId(options.getDLPParent())
                     .setHeaders(selectedColumns)

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
@@ -43,6 +43,11 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
 
   void setDeidentifyTemplateName(String value);
 
+  @Description("DLP ReIdentify Template Name")
+  String getReidentifyTemplateName();
+
+  void setReidentifyTemplateName(String value);
+
   @Description("DLP method deid,inspect,reid")
   @Default.Enum("INSPECT")
   DLPMethod getDLPMethod();
@@ -115,10 +120,12 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
 
   void setHeaders(List<String> topic);
 
-  @Description("Number of shards for DLP request batches. "
-      + "Can be used to controls parallelism of DLP requests.")
+  @Description(
+      "Number of shards for DLP request batches. "
+          + "Can be used to controls parallelism of DLP requests.")
   @Default.Integer(100)
   int getNumShardsPerDLPRequestBatching();
+
   void setNumShardsPerDLPRequestBatching(int value);
 
   class FileTypeFactory implements DefaultValueFactory<FileType> {

--- a/src/main/java/com/google/swarm/tokenization/beam/ShardRows.java
+++ b/src/main/java/com/google/swarm/tokenization/beam/ShardRows.java
@@ -57,8 +57,9 @@ public class ShardRows
       throw new RuntimeException(e);
     }
 
-    if(numberOfShards == UNDEFINED_NUMBER_OF_SHARDS) {
-      DLPTextToBigQueryStreamingV2PipelineOptions options = input.getPipeline().getOptions().as(DLPTextToBigQueryStreamingV2PipelineOptions.class);
+    if (numberOfShards == UNDEFINED_NUMBER_OF_SHARDS) {
+      DLPTextToBigQueryStreamingV2PipelineOptions options =
+          input.getPipeline().getOptions().as(DLPTextToBigQueryStreamingV2PipelineOptions.class);
       numberOfShards = options.getNumShardsPerDLPRequestBatching();
     }
 

--- a/src/main/java/com/google/swarm/tokenization/common/BigQueryDynamicWriteTransform.java
+++ b/src/main/java/com/google/swarm/tokenization/common/BigQueryDynamicWriteTransform.java
@@ -67,14 +67,15 @@ public abstract class BigQueryDynamicWriteTransform
   @Override
   public WriteResult expand(PCollection<KV<String, TableRow>> input) {
 
-    Write<KV<String, TableRow>> transform = BigQueryIO.<KV<String, TableRow>>write()
-        .to(new BQDestination(datasetId(), projectId()))
-        .withFormatFunction(KV::getValue)
-        .withWriteDisposition(WriteDisposition.WRITE_APPEND)
-        .withoutValidation()
-        .ignoreInsertIds()
-        .withMethod(Write.Method.STREAMING_INSERTS)
-        .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED);
+    Write<KV<String, TableRow>> transform =
+        BigQueryIO.<KV<String, TableRow>>write()
+            .to(new BQDestination(datasetId(), projectId()))
+            .withFormatFunction(KV::getValue)
+            .withWriteDisposition(WriteDisposition.WRITE_APPEND)
+            .withoutValidation()
+            .ignoreInsertIds()
+            .withMethod(Write.Method.STREAMING_INSERTS)
+            .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED);
 
     if (input.getPipeline().getOptions().as(StreamingOptions.class).isStreaming()) {
       transform = transform.withAutoSharding();

--- a/src/main/java/com/google/swarm/tokenization/common/DLPTransform.java
+++ b/src/main/java/com/google/swarm/tokenization/common/DLPTransform.java
@@ -56,6 +56,9 @@ public abstract class DLPTransform
   @Nullable
   public abstract String deidTemplateName();
 
+  @Nullable
+  public abstract String reidTemplateName();
+
   public abstract Integer batchSize();
 
   public abstract String projectId();
@@ -74,6 +77,8 @@ public abstract class DLPTransform
     public abstract Builder setInspectTemplateName(String inspectTemplateName);
 
     public abstract Builder setDeidTemplateName(String inspectTemplateName);
+
+    public abstract Builder setReidTemplateName(String reidTemplateName);
 
     public abstract Builder setBatchSize(Integer batchSize);
 
@@ -145,7 +150,7 @@ public abstract class DLPTransform
                       .setColumnDelimiter(columnDelimiter())
                       .setHeaderColumns(headers())
                       .setInspectTemplateName(inspectTemplateName())
-                      .setReidentifyTemplateName(deidTemplateName())
+                      .setReidentifyTemplateName(reidTemplateName())
                       .setProjectId(projectId())
                       .build())
               .apply(


### PR DESCRIPTION
- Bug fix: DLP templates recordTransformations are case sensetive. Query for re-identification of deidentified data is changed to inculde camle case.
- Added reidentification into pipeline option params: to decouple input arguments confusion and decoupling reidentification and de-identification.
- Batch re-identification command is changed in README.