### PR TITLE
Excluding csv header row in the output of SplitCSVFile Transform

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/common/CSVFileReaderSplitDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/common/CSVFileReaderSplitDoFn.java
@@ -54,6 +54,7 @@ public class CSVFileReaderSplitDoFn extends DoFn<KV<String, ReadableFile>, KV<St
       while (tracker.tryClaim(reader.getStartOfNextRecord())) {
         Long readerPosition = reader.getStartOfNextRecord();
         reader.readNextRecord();
+        // Skip CSV header row so that it does not get included in the data being de-identified.
         if (readerPosition == 0) {
           continue;
         }

--- a/src/main/java/com/google/swarm/tokenization/common/CSVFileReaderSplitDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/common/CSVFileReaderSplitDoFn.java
@@ -52,7 +52,11 @@ public class CSVFileReaderSplitDoFn extends DoFn<KV<String, ReadableFile>, KV<St
           new FileReader(
               channel, tracker.currentRestriction().getFrom(), recordDelimiter.getBytes());
       while (tracker.tryClaim(reader.getStartOfNextRecord())) {
+        Long readerPosition = reader.getStartOfNextRecord();
         reader.readNextRecord();
+        if (readerPosition == 0) {
+          continue;
+        }
         String contents = reader.getCurrent().toStringUtf8();
         String key = fileName;
         numberOfRowsRead.inc();

--- a/src/main/java/com/google/swarm/tokenization/common/CSVFileReaderSplitDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/common/CSVFileReaderSplitDoFn.java
@@ -52,7 +52,7 @@ public class CSVFileReaderSplitDoFn extends DoFn<KV<String, ReadableFile>, KV<St
           new FileReader(
               channel, tracker.currentRestriction().getFrom(), recordDelimiter.getBytes());
       while (tracker.tryClaim(reader.getStartOfNextRecord())) {
-        Long readerPosition = reader.getStartOfNextRecord();
+        long readerPosition = reader.getStartOfNextRecord();
         reader.readNextRecord();
         // Skip CSV header row so that it does not get included in the data being de-identified.
         if (readerPosition == 0) {


### PR DESCRIPTION
The header row of CSV files also goes through the de-identification transform (DLPTransform) in every pipeline. This gives error while applying any integer-specific template like "Bucketing of 'Age' field" as the header value getting de-identified is "Age" which is not an integer. To resolve, header row is being excluded from the records sent for de-identification from SplitCSVFile transform. 