### PR TITLE
Removing outputKey computation to resolve error logs in pipeline

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/avro/AvroReaderSplittableDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/avro/AvroReaderSplittableDoFn.java
@@ -82,8 +82,9 @@ public class AvroReaderSplittableDoFn
         GenericRecord record = fileReader.next();
 
         // Output the Avro record
-        String outputKey = String.format("%s~%d", fileName, new Random().nextInt(keyRange));
-        c.outputWithTimestamp(KV.of(outputKey, record), Instant.now());
+        // Removed outputKey computation as it was unnecessary 
+        // and creating error logs in the pipeline
+        c.outputWithTimestamp(KV.of(fileName, record), Instant.now());
         numberOfAvroRecordsIngested.inc();
       }
     }

--- a/src/main/java/com/google/swarm/tokenization/avro/AvroReaderSplittableDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/avro/AvroReaderSplittableDoFn.java
@@ -82,8 +82,6 @@ public class AvroReaderSplittableDoFn
         GenericRecord record = fileReader.next();
 
         // Output the Avro record
-        // Removed outputKey computation as it was unnecessary 
-        // and creating error logs in the pipeline
         c.outputWithTimestamp(KV.of(fileName, record), Instant.now());
         numberOfAvroRecordsIngested.inc();
       }


### PR DESCRIPTION
Fixing the AvroReaderSplittableDoFn for Avro formats to avoid appending random number to filename as it is unnecessary and creates error logs in the pipeline.

All the changes were tested on AVRO file format of size around 20 MB.