### PR TITLE
Handling resource exhausted exception

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
@@ -196,6 +196,8 @@ public class DLPTextToBigQueryStreamingV2 {
                 .setHeaders(headers)
                 .setColumnDelimiter(options.getColumnDelimiter())
                 .setJobName(options.getJobName())
+                .setDlpApiRetryCount(options.getDlpApiRetryCount())
+                .setInitialBackoff(options.getInitialBackoff())
                 .build())
         .get(Util.inspectOrDeidSuccess)
         .apply(

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
@@ -121,6 +121,16 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
   int getNumShardsPerDLPRequestBatching();
   void setNumShardsPerDLPRequestBatching(int value);
 
+  @Description("Number of retries in case of transient errors in dlp api")
+  @Default.Integer(10)
+  int getDlpApiRetryCount();
+  void setDlpApiRetryCount(int value);
+
+  @Description("Initial backoff (in seconds) for retries with exponential backoff")
+  @Default.Integer(5)
+  int getInitialBackoff();
+  void setInitialBackoff(int value);
+
   class FileTypeFactory implements DefaultValueFactory<FileType> {
     @Override
     public FileType create(PipelineOptions options) {

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
@@ -121,7 +121,7 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
   int getNumShardsPerDLPRequestBatching();
   void setNumShardsPerDLPRequestBatching(int value);
 
-  @Description("Number of retries in case of transient errors in dlp api")
+  @Description("Number of retries in case of transient errors in DLP API")
   @Default.Integer(10)
   int getDlpApiRetryCount();
   void setDlpApiRetryCount(int value);

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
@@ -129,6 +129,11 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
   @Description("Initial backoff (in seconds) for retries with exponential backoff")
   @Default.Integer(5)
   int getInitialBackoff();
+
+  /**
+   * Initial backoff (in seconds) for retries with exponential backoff.
+   * See {@link org.apache.beam.sdk.util.FluentBackoff.BackoffImpl#nextBackOffMillis()} for details on how the exponential backoff is implemented.
+   */
   void setInitialBackoff(int value);
 
   class FileTypeFactory implements DefaultValueFactory<FileType> {

--- a/src/main/java/com/google/swarm/tokenization/beam/DLPDeidentifyText.java
+++ b/src/main/java/com/google/swarm/tokenization/beam/DLPDeidentifyText.java
@@ -334,18 +334,15 @@ public abstract class DLPDeidentifyText
                   dlpServiceClient.deidentifyContent(this.requestBuilder.build());
           c.output(KV.of(fileName, response));
           break;
-        }
-        catch(ResourceExhaustedException e) {
+        }catch(ResourceExhaustedException e) {
             retry = BackOffUtils.next(Sleeper.DEFAULT, backoff);
             if(retry){
                 LOG.warn("Error in DLP API, Retrying...");
-            }
-            else{
+            }else{
                 numberOfDLPRowBagsFailedDeid.inc();
                 LOG.error("Retried {} times unsuccessfully. Some records were not de-identified. Exception: {}", this.dlpApiRetryCount, e.getMessage());    
             }
-        }
-        catch (ApiException e) {
+        }catch (ApiException e) {
             LOG.error("DLP API returned error. Some records were not de-identified {}", e.getMessage()); 
             retry = false;
         }

--- a/src/main/java/com/google/swarm/tokenization/common/DLPTransform.java
+++ b/src/main/java/com/google/swarm/tokenization/common/DLPTransform.java
@@ -68,6 +68,10 @@ public abstract class DLPTransform
 
   public abstract PCollectionView<Map<String, List<String>>> headers();
 
+  public abstract Integer dlpApiRetryCount();
+
+  public abstract Integer initialBackoff();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -86,6 +90,10 @@ public abstract class DLPTransform
     public abstract Builder setDlpmethod(DLPMethod method);
 
     public abstract Builder setJobName(String jobName);
+
+    public abstract Builder setDlpApiRetryCount(Integer dlpApiRetryCount);
+
+    public abstract Builder setInitialBackoff(Integer initialBackoff);
 
     public abstract DLPTransform build();
   }
@@ -128,6 +136,8 @@ public abstract class DLPTransform
                       .setInspectTemplateName(inspectTemplateName())
                       .setDeidentifyTemplateName(deidTemplateName())
                       .setProjectId(projectId())
+                      .setDlpApiRetryCount(dlpApiRetryCount())
+                      .setInitialBackoff(initialBackoff())
                       .build())
               .apply(
                   "ConvertDeidResponse",


### PR DESCRIPTION
Introduced retries using exponential backoff in case the dlp deid fails with RESOURCE_EXHAUSTED error.

Testing done:

- Tested the pipeline for 20MB csv file and by reducing the DLP API quota for Number of requests per minute. 
- Pipeline options passed were as follows:
- dlpApiRetryCount=12 
- initialBackoff=5
- DLP APIs were retried for 7 times and the expected number of unique rows were written to the BQ table