### PR TITLE
Support for CSV extension with custom delimiter and TSV file format

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2.java
@@ -114,6 +114,7 @@ public class DLPTextToBigQueryStreamingV2 {
             ExtractColumnNamesTransform.newBuilder()
                 .setFileType(options.getFileType())
                 .setHeaders(options.getHeaders())
+                .setColumnDelimiter(options.getColumnDelimiter())
                 .build());
 
     PCollection<KV<String, Table.Row>> records;
@@ -129,6 +130,8 @@ public class DLPTextToBigQueryStreamingV2 {
                 .setCoder(KvCoder.of(StringUtf8Coder.of(), GenericRecordCoder.of()))
                 .apply(ParDo.of(new ConvertAvroRecordToDlpRowDoFn()));
         break;
+      case TSV:
+        options.setColumnDelimiter('\t');
       case CSV:
         records =
             inputFiles

--- a/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
+++ b/src/main/java/com/google/swarm/tokenization/DLPTextToBigQueryStreamingV2PipelineOptions.java
@@ -159,6 +159,11 @@ public interface DLPTextToBigQueryStreamingV2PipelineOptions
           .toLowerCase()
           .endsWith(".txt")) {
         return FileType.TXT;
+      } else if (((DLPTextToBigQueryStreamingV2PipelineOptions) options)
+          .getFilePattern()
+          .toLowerCase()
+          .endsWith(".tsv")) {
+        return FileType.TSV;
       } else {
         return FileType.CSV;
       }

--- a/src/main/java/com/google/swarm/tokenization/common/CSVColumnNamesDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/common/CSVColumnNamesDoFn.java
@@ -31,6 +31,12 @@ public class CSVColumnNamesDoFn extends DoFn<KV<String, ReadableFile>, KV<String
 
   public static final Logger LOG = LoggerFactory.getLogger(CSVColumnNamesDoFn.class);
 
+  private Character columnDelimiter;
+
+  public CSVColumnNamesDoFn(Character columnDelimiter) {
+    this.columnDelimiter = columnDelimiter;
+  }
+
   @ProcessElement
   public void processElement(ProcessContext c) {
     ReadableFile file = c.element().getValue();
@@ -40,6 +46,7 @@ public class CSVColumnNamesDoFn extends DoFn<KV<String, ReadableFile>, KV<String
 
       CSVFormat.DEFAULT
           .withFirstRecordAsHeader()
+          .withDelimiter(columnDelimiter)
           .parse(br)
           .getHeaderMap()
           .keySet()

--- a/src/main/java/com/google/swarm/tokenization/common/ExtractColumnNamesTransform.java
+++ b/src/main/java/com/google/swarm/tokenization/common/ExtractColumnNamesTransform.java
@@ -42,12 +42,17 @@ public abstract class ExtractColumnNamesTransform
   @Nullable
   public abstract List<String> headers();
 
+  public abstract Character columnDelimiter();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
     public abstract ExtractColumnNamesTransform.Builder setFileType(FileType fileType);
 
     public abstract ExtractColumnNamesTransform.Builder setHeaders(List<String> headers);
+
+    public abstract ExtractColumnNamesTransform.Builder setColumnDelimiter(
+        Character columnDelimiter);
 
     public abstract ExtractColumnNamesTransform build();
   }
@@ -62,7 +67,11 @@ public abstract class ExtractColumnNamesTransform
     PCollection<KV<String, List<String>>> readHeader;
     switch (fileType()) {
       case CSV:
-        readHeader = input.apply("ReadHeader", ParDo.of(new CSVColumnNamesDoFn()));
+        readHeader = input.apply("ReadHeader", ParDo.of(new CSVColumnNamesDoFn(columnDelimiter())));
+        break;
+
+      case TSV:
+        readHeader = input.apply("ReadHeader", ParDo.of(new CSVColumnNamesDoFn('\t')));
         break;
 
       case AVRO:

--- a/src/main/java/com/google/swarm/tokenization/common/SanitizeFileNameDoFn.java
+++ b/src/main/java/com/google/swarm/tokenization/common/SanitizeFileNameDoFn.java
@@ -34,7 +34,8 @@ public class SanitizeFileNameDoFn extends DoFn<ReadableFile, KV<String, Readable
 
   public static final Logger LOG = LoggerFactory.getLogger(SanitizeFileNameDoFn.class);
   private static final Set<String> ALLOWED_FILE_EXTENSIONS =
-      Arrays.asList("csv", "avro", "jsonl", "txt").stream().collect(Collectors.toUnmodifiableSet());
+      Arrays.asList("csv", "tsv", "avro", "jsonl", "txt").stream()
+          .collect(Collectors.toUnmodifiableSet());
   ;
   // Regular expression that matches valid BQ table IDs
   private static final String TABLE_REGEXP = "[-\\w$@]{1,1024}";

--- a/src/main/java/com/google/swarm/tokenization/common/Util.java
+++ b/src/main/java/com/google/swarm/tokenization/common/Util.java
@@ -78,7 +78,9 @@ public class Util {
     CSV,
     AVRO,
     JSONL,
-    TXT
+    TXT,
+
+    TSV
   }
 
   public static final Gson gson = new Gson();


### PR DESCRIPTION
The TAB column delimiter for TSV is hardcoded to avoid forcing user to specify \t on command line which is tricky.

For CSV with | as custom delimiter sample command line would look like:
>"gradle build ... -Pargs="... --columnDelimiter=|"

For TSV the command would look like
>"gradle build ... -Pargs="... --filePattern=gs://bhaskar-dlp-dataflow-test001-demo-data/CC_small_sample.tsv"

Tested file with .csv extension using | as delimiter. (small file 10 lines of CC Records, 20 MB file) Tested file with .tsv, created using online converter (small file 10 liines of CC Records, 20 MB file)