### PR TITLE
Removing the gh-test-2 lable

### DIFF
--- a/.github/workflows/deid-run.yml
+++ b/.github/workflows/deid-run.yml
@@ -21,7 +21,6 @@ jobs:
   run-and-verify:
     runs-on:
       - self-hosted
-      - gh-test-2
 
     timeout-minutes: 30
 


### PR DESCRIPTION
Removing the gh-test-2 lable for self-hosted runner, as no runner was provided for the new setup.