### PR TITLE
Converting conditions to single element

### DIFF
--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
                 --region=us-central1 \
-                --project=${{env.PROJECT_ID}} \
+#                --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \
@@ -265,7 +265,7 @@ jobs:
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
                 --region=us-central1 \
-                --project=${{env.PROJECT_ID}} \
+#                --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \
@@ -320,7 +320,7 @@ jobs:
           echo "Verified number of rows in ${{env.INPUT_FILE_NAME}}_re_id: $row_count."
 
   clean-up:
-    if: ${{ always() }}
+    if: "!cancelled()"
     needs:
       - generate-uuid
       - inspection
@@ -347,8 +347,8 @@ jobs:
         run: |
           inspect_job_data=$(gcloud dataflow jobs list --project ${{env.PROJECT_ID}} --status active --format json --filter="name=${{env.INSPECT_JOB_NAME}}")
           inspect_job_id=$(echo "$inspect_job_data" | jq -r '.[].id')
-          if !$inspect_job_id; then
-            echo "No job found with name: $inspect_job_id."
+          if [[ "$inspect_job_id" == "" ]]; then
+            echo "No job found with name: ${{env.INSPECT_JOB_NAME}}."
           else
             gcloud dataflow jobs cancel $inspect_job_id --project ${{env.PROJECT_ID}}
           fi
@@ -360,8 +360,8 @@ jobs:
         run: |
           deid_job_data=$(gcloud dataflow jobs list --project ${{env.PROJECT_ID}} --status active --format json --filter="name=${{env.DEID_JOB_NAME}}")
           deid_job_id=$(echo "$deid_job_data" | jq -r '.[].id')
-          if !$deid_job_id; then
-            echo "No job found with name: $deid_job_id."
+          if [[ "$deid_job_id" == "" ]]; then
+            echo "No job found with name: ${{env.INSPECT_JOB_NAME}}."
           else
             gcloud dataflow jobs cancel $deid_job_id --project ${{env.PROJECT_ID}}
           fi

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
                 --region=us-central1 \
+                --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \
@@ -264,6 +265,7 @@ jobs:
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
                 --region=us-central1 \
+                --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \
@@ -359,7 +361,7 @@ jobs:
           deid_job_data=$(gcloud dataflow jobs list --project ${{env.PROJECT_ID}} --status active --format json --filter="name=${{env.DEID_JOB_NAME}}")
           deid_job_id=$(echo "$deid_job_data" | jq -r '.[].id')
           if [[ "$deid_job_id" == "" ]]; then
-            echo "No job found with name: ${{env.INSPECT_JOB_NAME}}."
+            echo "No job found with name: ${{env.DEID_JOB_NAME}}."
           else
             gcloud dataflow jobs cancel $deid_job_id --project ${{env.PROJECT_ID}}
           fi

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -89,7 +89,6 @@ jobs:
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
                 --region=us-central1 \
-#                --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \
@@ -265,7 +264,6 @@ jobs:
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
                 --region=us-central1 \
-#                --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \


### PR DESCRIPTION
Converting conditions to single element in shell commands, to avoid errors in specific cases.
For more details, refer [here](https://github.com/GoogleCloudPlatform/dlp-dataflow-deidentification/actions/runs/5679449799/job/15423507931).

Testing: Done