### PR TITLE
CI changes for Replacing File Polling with Pub Sub

### DIFF
--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -214,7 +214,7 @@ jobs:
           done
           echo "Verified number of tables in BQ with id ${{env.INPUT_FILE_NAME}}*: $table_count ."
 
-      - name: Verify distinct rows
+      - name: Verify distinct rows of existing file
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
@@ -232,6 +232,12 @@ jobs:
             fi
             echo "Got number of rows in ${{env.INPUT_FILE_NAME}}: $row_count."
           done
+          echo "# records in input CSV file are: $rc_orig."
+          echo "Verified number of rows in ${{env.INPUT_FILE_NAME}}: $row_count."
+      - name: Verify distinct rows of newly added file
+        env:
+          DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
+        run: |
           rc_orig=$(($(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l ) -1))
           not_verified=true
           row_count=0

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -201,7 +201,7 @@ jobs:
           not_verified=true
           table_count=0
           while $not_verified; do
-            table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id="${{env.INPUT_FILE_NAME}}"' | wc -l ) -1))
+            table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id="${{env.INPUT_FILE_NAME}}*"' | wc -l ) -1))
             if [[ "$table_count" == "2" ]]; then
               echo "PASSED";
               not_verified=false;

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -10,6 +10,7 @@ env:
   PROJECT_ID: "dlp-dataflow-deid-ci-392604"
   DATASET_ID: "demo_dataset"
   GCS_BUCKET: "dlp-dataflow-deid-ci-392604-demo-data"
+  GCS_NOTIFICATION_TOPIC: "projects/dlp-dataflow-deid-ci-392604/topics/dlp-dataflow-deid-ci-gcs-notification-topic"
   INPUT_FILE_NAME: "tiny_csv"
   INSPECT_TEMPLATE_PATH: "projects/dlp-dataflow-deid-ci-392604/locations/global/inspectTemplates/dlp-demo-inspect-latest-1689137435622"
   DEID_TEMPLATE_PATH: "projects/dlp-dataflow-deid-ci-392604/locations/global/deidentifyTemplates/dlp-demo-deid-latest-1689137435622"
@@ -88,20 +89,24 @@ jobs:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
+                --streaming --enableStreamingEngine \
                 --region=us-central1 \
                 --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=1 \
                 --maxNumWorkers=2 \
                 --runner=DataflowRunner \
-                --filePattern=gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}.csv \
+                --filePattern=gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}*.csv \
                 --dataset=${{env.DATASET_ID}} \
                 --workerMachineType=n1-highmem-4 \
                 --inspectTemplateName=${{env.INSPECT_TEMPLATE_PATH}} \
                 --batchSize=200000 \
                 --DLPMethod=INSPECT \
                 --serviceAccount=$SERVICE_ACCOUNT_EMAIL \
-                --jobName=${{env.INSPECT_JOB_NAME}}"
+                --jobName=${{env.INSPECT_JOB_NAME}} \
+                --gcsNotificationTopic=${{env.GCS_NOTIFICATION_TOPIC}}"
+          sleep 30s
+          gsutil cp gs://${{env.GCS_BUCKET}}/temp/csv/tiny_csv_pub_sub.csv gs://${{env.GCS_BUCKET}}
 
       - name: Verify BQ table
         env:
@@ -111,7 +116,7 @@ jobs:
           table_count=0
           while $not_verified; do
             table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id="${{env.INSPECTION_TABLE_ID}}"'  | wc -l ) -1))
-            if [[ "$table_count" == "1" ]]; then
+            if [[ "$table_count" == "2" ]]; then
               echo "PASSED";
               not_verified=false;
             else
@@ -165,13 +170,14 @@ jobs:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
           gradle run -DmainClass=com.google.swarm.tokenization.DLPTextToBigQueryStreamingV2 -Pargs=" \
+                --streaming --enableStreamingEngine \
                 --region=us-central1 \
                 --project=${{env.PROJECT_ID}} \
                 --tempLocation=gs://${{env.GCS_BUCKET}}/temp \
                 --numWorkers=2 \
                 --maxNumWorkers=3 \
                 --runner=DataflowRunner \
-                --filePattern=gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}.csv \
+                --filePattern=gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}*.csv \
                 --dataset=${{env.DATASET_ID}} \
                 --workerMachineType=n1-highmem-4 \
                 --inspectTemplateName=${{env.INSPECT_TEMPLATE_PATH}} \
@@ -179,7 +185,14 @@ jobs:
                 --batchSize=200000 \
                 --DLPMethod=DEID \
                 --serviceAccount=${SERVICE_ACCOUNT_EMAIL} \
-                --jobName=${{env.DEID_JOB_NAME}}"
+                --jobName=${{env.DEID_JOB_NAME}} \
+                --gcsNotificationTopic=${{env.GCS_NOTIFICATION_TOPIC}}"
+          sleep 30s
+          if gsutil stat gs://$BUCKET_NAME/$FILE_NAME; then
+            echo "Pub Sub CSV File exists hence need not copy anymore"
+          else
+            gsutil cp gs://${{env.GCS_BUCKET}}/temp/csv/tiny_csv_pub_sub.csv gs://${{env.GCS_BUCKET}}
+          fi
 
       - name: Verify BQ tables
         env:
@@ -189,7 +202,7 @@ jobs:
           table_count=0
           while $not_verified; do
             table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id="${{env.INPUT_FILE_NAME}}"' | wc -l ) -1))
-            if [[ "$table_count" == "1" ]]; then
+            if [[ "$table_count" == "2" ]]; then
               echo "PASSED";
               not_verified=false;
             else

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -122,6 +122,7 @@ jobs:
             else
               sleep 30s
             fi
+            echo "Got number of tables in BQ with id ${{env.INSPECTION_TABLE_ID}}: $table_count ."
           done
           echo "Verified number of tables in BQ with id ${{env.INSPECTION_TABLE_ID}}: $table_count ."
 
@@ -140,6 +141,7 @@ jobs:
             else
               sleep 30s
             fi
+            echo "Got number of rows in ${{env.INSPECTION_TABLE_ID}}: $row_count."
           done
           echo "Verified number of rows in ${{env.INSPECTION_TABLE_ID}}: $row_count."
 
@@ -208,8 +210,9 @@ jobs:
             else
               sleep 30s
             fi
+            echo "Got number of tables in BQ with id ${{env.INPUT_FILE_NAME}}*: $table_count ."
           done
-          echo "Verified number of tables in BQ with id ${{env.INPUT_FILE_NAME}}: $table_count ."
+          echo "Verified number of tables in BQ with id ${{env.INPUT_FILE_NAME}}*: $table_count ."
 
       - name: Verify distinct rows
         env:
@@ -227,6 +230,7 @@ jobs:
             else
               sleep 30s
             fi
+            echo "Got number of rows in ${{env.INPUT_FILE_NAME}}: $row_count."
           done
           rc_orig=$(($(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l ) -1))
           not_verified=true
@@ -240,6 +244,7 @@ jobs:
             else
               sleep 30s
             fi
+            echo "Got number of rows in ${{env.INPUT_FILE_NAME}}_pub_sub: $row_count."
           done
           echo "# records in input CSV file are: $rc_orig."
           echo "Verified number of rows in ${{env.INPUT_FILE_NAME}}: $row_count."

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -380,7 +380,7 @@ jobs:
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
-          bq rm -r -f -d ${{env.PROJECT_ID}}:${{env.DATASET_ID}}
+          #bq rm -r -f -d ${{env.PROJECT_ID}}:${{env.DATASET_ID}}
           gsutil rm -f gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv
 
       - name: Cancel Inspection Job

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -18,7 +18,7 @@ env:
   SERVICE_ACCOUNT_EMAIL: "demo-service-account@dlp-dataflow-deid-ci-392604.iam.gserviceaccount.com"
   PUBSUB_TOPIC_NAME: "demo-topic"
   INSPECTION_TABLE_ID: "dlp_inspection_result"
-  NUM_INSPECTION_RECORDS: "60"
+  NUM_INSPECTION_RECORDS: "120"
   REIDENTIFICATION_QUERY_FILE: "reid_query.sql"
 
 jobs:
@@ -203,7 +203,7 @@ jobs:
           not_verified=true
           table_count=0
           while $not_verified; do
-            table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id="${{env.INPUT_FILE_NAME}}*"' | wc -l ) -1))
+            table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id LIKE "${{env.INPUT_FILE_NAME}}%"' | wc -l ) -1))
             if [[ "$table_count" == "2" ]]; then
               echo "PASSED";
               not_verified=false;

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -18,7 +18,7 @@ env:
   SERVICE_ACCOUNT_EMAIL: "demo-service-account@dlp-dataflow-deid-ci-392604.iam.gserviceaccount.com"
   PUBSUB_TOPIC_NAME: "demo-topic"
   INSPECTION_TABLE_ID: "dlp_inspection_result"
-  NUM_INSPECTION_RECORDS: "129"
+  NUM_INSPECTION_RECORDS_THRESHOLD: "50"
   REIDENTIFICATION_QUERY_FILE: "reid_query.sql"
 
 jobs:
@@ -135,7 +135,7 @@ jobs:
           while $not_verified; do
             row_count_json=$(bq query --use_legacy_sql=false --format json 'SELECT COUNT(*) FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}.${{env.INSPECTION_TABLE_ID}}`')
             row_count=$(echo "$row_count_json" | jq -r '.[].f0_')
-            if [[ "$row_count" == ${{env.NUM_INSPECTION_RECORDS}} ]]; then
+            if [[ "$row_count" -gt ${{env.NUM_INSPECTION_RECORDS}} ]]; then
               echo "PASSED";
               not_verified=false;
             else

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -18,7 +18,7 @@ env:
   SERVICE_ACCOUNT_EMAIL: "demo-service-account@dlp-dataflow-deid-ci-392604.iam.gserviceaccount.com"
   PUBSUB_TOPIC_NAME: "demo-topic"
   INSPECTION_TABLE_ID: "dlp_inspection_result"
-  NUM_INSPECTION_RECORDS: "30"
+  NUM_INSPECTION_RECORDS: "60"
   REIDENTIFICATION_QUERY_FILE: "reid_query.sql"
 
 jobs:
@@ -116,7 +116,7 @@ jobs:
           table_count=0
           while $not_verified; do
             table_count=$(($(bq query --use_legacy_sql=false --format csv 'SELECT * FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}`.__TABLES__ WHERE table_id="${{env.INSPECTION_TABLE_ID}}"'  | wc -l ) -1))
-            if [[ "$table_count" == "2" ]]; then
+            if [[ "$table_count" == "1" ]]; then
               echo "PASSED";
               not_verified=false;
             else
@@ -220,6 +220,19 @@ jobs:
           row_count=0
           while $not_verified; do
             row_count_json=$(bq query --use_legacy_sql=false --format json 'SELECT COUNT(DISTINCT(ID)) FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}.${{env.INPUT_FILE_NAME}}`')
+            row_count=$(echo "$row_count_json" | jq -r '.[].f0_')
+            if [[ "$row_count" == "$rc_orig" ]]; then
+              echo "PASSED";
+              not_verified=false;
+            else
+              sleep 30s
+            fi
+          done
+          rc_orig=$(($(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l ) -1))
+          not_verified=true
+          row_count=0
+          while $not_verified; do
+            row_count_json=$(bq query --use_legacy_sql=false --format json 'SELECT COUNT(DISTINCT(ID)) FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}.${{env.INPUT_FILE_NAME}}_pub_sub`')
             row_count=$(echo "$row_count_json" | jq -r '.[].f0_')
             if [[ "$row_count" == "$rc_orig" ]]; then
               echo "PASSED";
@@ -346,12 +359,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Clean-up BQ dataset
+      - name: Clean-up BQ dataset and GCS Bucket
         if: "!cancelled()"
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
           bq rm -r -f -d ${{env.PROJECT_ID}}:${{env.DATASET_ID}}
+          gsutil rm -f gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv
 
       - name: Cancel Inspection Job
         if: "!cancelled()"

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -238,12 +238,17 @@ jobs:
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
-          rc_orig=$(($(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l ) -1))
+          echo "DEBUG LOG 1"
+          rc_orig=$(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l )
+          echo "DEBUG LOG 2 : $rc_orig"
           not_verified=true
-          row_count=0
+          echo "DEBUG LOG 3"
           while $not_verified; do
+            echo "DEBUG LOG LOOP 1"
             row_count_json=$(bq query --use_legacy_sql=false --format json 'SELECT COUNT(DISTINCT(ID)) FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}.${{env.INPUT_FILE_NAME}}_pub_sub`')
+            echo "DEBUG LOG LOOP 2 $row_count_json"
             row_count=$(echo "$row_count_json" | jq -r '.[].f0_')
+            echo "DEBUG LOG LOOP 3 $row_count"
             if [[ "$row_count" == "$rc_orig" ]]; then
               echo "PASSED";
               not_verified=false;

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -238,17 +238,11 @@ jobs:
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
-          echo "DEBUG LOG 1"
-          rc_orig=$(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l )
-          echo "DEBUG LOG 2 : $rc_orig"
+          rc_orig=$(($(gcloud storage cat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv | wc -l ) -1))
           not_verified=true
-          echo "DEBUG LOG 3"
           while $not_verified; do
-            echo "DEBUG LOG LOOP 1"
             row_count_json=$(bq query --use_legacy_sql=false --format json 'SELECT COUNT(DISTINCT(ID)) FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}.${{env.INPUT_FILE_NAME}}_pub_sub`')
-            echo "DEBUG LOG LOOP 2 $row_count_json"
             row_count=$(echo "$row_count_json" | jq -r '.[].f0_')
-            echo "DEBUG LOG LOOP 3 $row_count"
             if [[ "$row_count" == "$rc_orig" ]]; then
               echo "PASSED";
               not_verified=false;

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -135,7 +135,7 @@ jobs:
           while $not_verified; do
             row_count_json=$(bq query --use_legacy_sql=false --format json 'SELECT COUNT(*) FROM `${{env.PROJECT_ID}}.${{env.DATASET_ID}}.${{env.INSPECTION_TABLE_ID}}`')
             row_count=$(echo "$row_count_json" | jq -r '.[].f0_')
-            if [[ "$row_count" -gt ${{env.NUM_INSPECTION_RECORDS}} ]]; then
+            if [[ "$row_count" -gt ${{env.NUM_INSPECTION_RECORDS_THRESHOLD}} ]]; then
               echo "PASSED";
               not_verified=false;
             else

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -190,7 +190,7 @@ jobs:
                 --jobName=${{env.DEID_JOB_NAME}} \
                 --gcsNotificationTopic=${{env.GCS_NOTIFICATION_TOPIC}}"
           sleep 30s
-          if gsutil stat gs://$BUCKET_NAME/$FILE_NAME; then
+          if gsutil stat gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv; then
             echo "Pub Sub CSV File exists hence need not copy anymore"
           else
             gsutil cp gs://${{env.GCS_BUCKET}}/temp/csv/tiny_csv_pub_sub.csv gs://${{env.GCS_BUCKET}}
@@ -234,6 +234,7 @@ jobs:
           done
           echo "# records in input CSV file are: $rc_orig."
           echo "Verified number of rows in ${{env.INPUT_FILE_NAME}}: $row_count."
+
       - name: Verify distinct rows of newly added file
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}

--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -18,7 +18,7 @@ env:
   SERVICE_ACCOUNT_EMAIL: "demo-service-account@dlp-dataflow-deid-ci-392604.iam.gserviceaccount.com"
   PUBSUB_TOPIC_NAME: "demo-topic"
   INSPECTION_TABLE_ID: "dlp_inspection_result"
-  NUM_INSPECTION_RECORDS: "120"
+  NUM_INSPECTION_RECORDS: "129"
   REIDENTIFICATION_QUERY_FILE: "reid_query.sql"
 
 jobs:
@@ -252,7 +252,7 @@ jobs:
             echo "Got number of rows in ${{env.INPUT_FILE_NAME}}_pub_sub: $row_count."
           done
           echo "# records in input CSV file are: $rc_orig."
-          echo "Verified number of rows in ${{env.INPUT_FILE_NAME}}: $row_count."
+          echo "Verified number of rows in ${{env.INPUT_FILE_NAME}}_pub_sub: $row_count."
 
   re-identification:
     needs:
@@ -374,7 +374,7 @@ jobs:
         env:
           DATASET_ID: ${{ needs.generate-uuid.outputs.output5 }}
         run: |
-          #bq rm -r -f -d ${{env.PROJECT_ID}}:${{env.DATASET_ID}}
+          bq rm -r -f -d ${{env.PROJECT_ID}}:${{env.DATASET_ID}}
           gsutil rm -f gs://${{env.GCS_BUCKET}}/${{env.INPUT_FILE_NAME}}_pub_sub.csv
 
       - name: Cancel Inspection Job


### PR DESCRIPTION
Adding the CI support for Replacing File Polling with Pub Sub.
- Introduced a new csv file to be copied into GCS Input bucket 30s after triggering the pipeline
- Added the streaming flags in pipeline
- Verified the deid pipeline checking number of tables being 2 now and number of distinct rows
- Cleaning up the new csv copied for further run

Testing : Automatically tested with PR through Github Actions