### PR TITLE
use filter by project-id to fetch project number

### DIFF
--- a/setup-data-tokeninzation-solution-v2.sh
+++ b/setup-data-tokeninzation-solution-v2.sh
@@ -23,7 +23,7 @@ export KEY_RING_NAME=demo-key-ring
 export KEY_NAME=demo-key
 export KEK_FILE_NAME=kek.json
 export TOKENIZING_ROLE_NAME="dlp_tokenizing_runner"
-export PROJECT_NUMBER=$(gcloud projects list --filter=${PROJECT_ID} --format="value(PROJECT_NUMBER)") 
+export PROJECT_NUMBER=$(gcloud projects list --filter="PROJECT_ID: ${PROJECT_ID}" --format="value(PROJECT_NUMBER)")
 export SERVICE_ACCOUNT_NAME=demo-service-account
 export REGION=us-central1
 export BQ_DATASET_NAME=demo_dataset


### PR DESCRIPTION
<B>Summary</B> :  Use project-id filter for fetching project number in setup script

<B>Description</B>: setup script uses gcloud projects lists and filters by project-id to fetch the project number. Adding --filter="PROJECT_ID: ..." ensures only single project-id gets selected</h4>

<B>Bug ID</B>: NA

<B>Public Documentation</B>: NA

<B>TESTED</B>: NA </h4>
