### PR TITLE
Updated logic to process array data types in parquet

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/parquet/GenericRecordFlattener.java
+++ b/src/main/java/com/google/swarm/tokenization/parquet/GenericRecordFlattener.java
@@ -98,12 +98,18 @@ public final class GenericRecordFlattener implements RecordFlattener<GenericReco
           break;
 
         case ARRAY:
-          List<?> arrayValues = (List<?>) value;
-          List<String> updatedValues = new ArrayList<>();
-          for (int index = 0; index < arrayValues.size(); index++) {
-            updatedValues.add(arrayValues.get(index).toString());
+          String listFieldKey =
+                  isBlank(parentKey) ? fieldName : String.format("%s.%s", parentKey, fieldName);
+          if (value == null) {
+            putValue(listFieldKey, Value.newBuilder().getDefaultInstanceForType());
+          } else {
+            List<?> arrayValues = (List<?>) value;
+            List<String> updatedValues = new ArrayList<>();
+            for (int index = 0; index < arrayValues.size(); index++) {
+              updatedValues.add(arrayValues.get(index).toString());
+            }
+            putValue(listFieldKey, Value.newBuilder().setStringValue(updatedValues.toString()).build());
           }
-          putValue(parentKey, Value.newBuilder().setStringValue(updatedValues.toString()).build());
           break;
 
         case UNION:

--- a/src/main/java/com/google/swarm/tokenization/parquet/GenericRecordFlattener.java
+++ b/src/main/java/com/google/swarm/tokenization/parquet/GenericRecordFlattener.java
@@ -99,7 +99,7 @@ public final class GenericRecordFlattener implements RecordFlattener<GenericReco
 
         case ARRAY:
           String listFieldKey =
-                  isBlank(parentKey) ? fieldName : String.format("%s.%s", parentKey, fieldName);
+              isBlank(parentKey) ? fieldName : String.format("%s.%s", parentKey, fieldName);
           if (value == null) {
             putValue(listFieldKey, Value.newBuilder().getDefaultInstanceForType());
           } else {
@@ -108,7 +108,8 @@ public final class GenericRecordFlattener implements RecordFlattener<GenericReco
             for (int index = 0; index < arrayValues.size(); index++) {
               updatedValues.add(arrayValues.get(index).toString());
             }
-            putValue(listFieldKey, Value.newBuilder().setStringValue(updatedValues.toString()).build());
+            putValue(
+                listFieldKey, Value.newBuilder().setStringValue(updatedValues.toString()).build());
           }
           break;
 


### PR DESCRIPTION
<h4> Summary (Short summary of what is being done) : </h4>
Updated logic to process array data types in parquet
<br>
<h4> Description (Describe in detail the fix made) : </h4>
Current logic to process ARRAY data types in parquet is breaking the pipeline. The field name is assigned a null value when the data type is an array. In turn, the pipeline throws "CoderException: cannot encode a null String". For more details, please refer to the attached buganizer ticket.
<br>
<h4> Bug ID (if any) : </h4>
b/310247478
<br>
<h4> Public Documentation (if any) : </h4>
<br>
<h4> TESTED (Test Cases with scenario and description - must have 1 positive and 1 negative scenario) : </h4>
Tested on the parquet file provided in the ticket.
