### PR TITLE
Updating the JsonObject method from getAsString() to toString()

### DIFF
--- a/src/main/java/com/google/swarm/tokenization/json/ConvertJsonRecordToDLPRow.java
+++ b/src/main/java/com/google/swarm/tokenization/json/ConvertJsonRecordToDLPRow.java
@@ -43,7 +43,7 @@ public class ConvertJsonRecordToDLPRow extends DoFn<KV<String, String>, KV<Strin
     json.keySet()
         .forEach(
             key -> {
-              String value = json.get(key).getAsString();
+              String value = json.get(key).toString();
               tableRowBuilder.addValues(Value.newBuilder().setStringValue(value));
             });
     Table.Row dlpRow = tableRowBuilder.build();


### PR DESCRIPTION
<h4> Summary (Short summary of what is being done) : </h4>
Updating the JsonObject method from getAsString() to toString()
<br>
<h4> Description (Describe in detail the fix made) : </h4>
The DEID pipeline was failing on JSONL files when it had nested structure. 
<br>
<br>
Pipeline uses getAsString() method call on JsonObject which throws exception with non-primitive data (nested structure in this case). Replacing getAsString() with toString() works. Please refer to [this](https://stackoverflow.com/questions/34120882/gson-jsonelement-getasstring-vs-jsonelement-tostring#:~:text=getAsString()%20is%20only%20defined,on%20all%20types%20of%20JsonElement%20.) stackoverflow link to understand the difference between the two.
<br>
<h4> Bug ID (if any) : </h4>
b/310247478
<br>
<h4> Public Documentation (if any) : </h4>
<br>
<h4> TESTED (Test Cases with scenario and description - must have 1 positive and 1 negative scenario) : </h4>
Tested DEID pipeline on the jsonl data file attached with the bug.
