### PR TITLE
Added CI tag to the jobs

### DIFF
--- a/.github/workflows/dlp-pipelines.yml
+++ b/.github/workflows/dlp-pipelines.yml
@@ -108,6 +108,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 5
 
@@ -128,6 +129,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 5
 
@@ -146,6 +148,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -231,6 +234,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -310,6 +314,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -388,6 +393,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -500,6 +506,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -581,6 +588,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -643,6 +651,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -724,6 +733,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -808,6 +818,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -882,6 +893,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 
@@ -993,6 +1005,7 @@ jobs:
 
     runs-on:
       - self-hosted
+      - CI
 
     timeout-minutes: 30
 


### PR DESCRIPTION
<h4> Summary (Short summary of what is being done) : </h4> Added CI tag to the runners used for CI
<br>
<h4> Description (Describe in detail the fix made) : </h4>
CI jobs in the repo are executed on runners labeled as "self-hosted". A new self hosted runner(which will be used for load testing) is added to the repo. This is leading to CI jobs being picked up by runner for load testing and hence the jobs are failing. 
To prevent this, we have added a new label - "CI" to the runners dedicated for CI. The type of machine to run the job on is defined using "runs-on" by specifying the labels of the runner. The pr includes changes to also include the CI label in the list of labels
<h4> Bug ID (if any) : </h4>b/328159627
<br>
<h4> Public Documentation (if any) : </h4>
<br>
<h4> TESTED (Test Cases with scenario and description - must have 1 positive and 1 negative scenario) : </h4>
